### PR TITLE
[codex] Improve Nix flake and add direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,23 @@
           inherit system;
           overlays = [(import rust-overlay)];
         };
+        inherit (pkgs) lib;
         toolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        cargoToml = lib.importTOML ./Cargo.toml;
+
+        nativeBuildInputs = with pkgs; [
+          pkg-config
+        ];
+
+        buildInputs = with pkgs; [
+          glib-networking
+          gobject-introspection
+          gtk4
+          libadwaita
+          libxkbcommon
+          wayland
+          glib
+        ];
 
         naersk-package = pkgs.callPackage naersk {
           cargo = toolchain;
@@ -33,30 +49,23 @@
           clippy = toolchain;
         };
       in {
-        devShell = with pkgs;
+        devShells.default = with pkgs;
           mkShell {
-            buildInputs = [
-              cargo
-              cargo-info
-              rustc
-              rustfmt
-              clippy
-              rust-analyzer
-              just
+            packages =
+              [
+                toolchain
+                cargo-info
+                rust-analyzer
+                just
 
-              eza
-              fd
-              fzf
-              bat
-
-              pkg-config
-              libxkbcommon
-              glib
-              gobject-introspection
-              gtk4
-              libadwaita
-            ];
-            RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+                eza
+                fd
+                fzf
+                bat
+              ]
+              ++ nativeBuildInputs
+              ++ buildInputs;
+            RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";
 
             shellHook = ''
               alias ls=eza
@@ -64,23 +73,31 @@
             '';
           };
 
+        devShell = self.devShells.${system}.default;
+
         packages.default = naersk-package.buildPackage {
-          name = "nmrs";
-          version = self.shortRev or self.dirtyShortRev;
+          pname = "nmrs-gui";
+          version = cargoToml.package.version;
           src = ./.;
 
-          buildInputs = with pkgs; [
-            pkg-config
-            wrapGAppsHook4
-            libxkbcommon
-            glib
-          ];
+          nativeBuildInputs =
+            nativeBuildInputs
+            ++ (with pkgs; [
+              wrapGAppsHook4
+            ]);
+          inherit buildInputs;
 
           postInstall = ''
             install -D nmrs.desktop -t $out/share/applications
           '';
 
-          meta.mainProgram = "nmrs-gui";
+          meta = with lib; {
+            description = cargoToml.package.description;
+            homepage = cargoToml.package.repository;
+            license = licenses.mit;
+            mainProgram = "nmrs-gui";
+            platforms = platforms.linux;
+          };
         };
       }
     );


### PR DESCRIPTION
## Summary

- expose the development shell as `devShells.default` while preserving the legacy `devShell` output
- share GTK and system dependencies between the dev shell and package build
- derive the package version and metadata from `Cargo.toml`
- add `.envrc` so direnv can load the flake shell automatically

## Validation

- `alejandra flake.nix`
- `nix flake show --all-systems`
- `nix develop --command cargo check`
- `nix build`
- `nix run . -- --help`
