### PR TITLE
Update Readme with nix flake instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,35 @@ cargo install nmrs-gui
 cargo install --path .
 ```
 
-Both install the `nmrs` binary.
+### Nix
+
+#### From source
+
+`nix run`
+
+#### Add to your system flake
+
+```nix
+# In flake.nix
+
+inputs = {
+  nmrs = {
+    url = "github:networkmanager-rs/nmrs-gui";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+}
+
+# In your packages list
+
+packages = [
+  inputs.nmrs.packages.${pkgs.stdenv.hostPlatform.system}.default
+];
+```
 
 ## Usage
 
 ```bash
-nmrs [OPTIONS]
+nmrs-gui [OPTIONS]
 
 Options:
   -V, --version    Print version and build hash


### PR DESCRIPTION
Given that the nixpkgs PR has run aground, I have added code snippets for how to install it to ones system as if it were in nixpkgs.

It is possible to set up a free [cachix](https://www.cachix.org/) build cache so users can install binaries, this is something that [other projects do](https://github.com/helix-editor/helix/blob/master/flake.nix#L96), and essentially makes the user experience the same as having it in nixpkgs - this would be the next step.